### PR TITLE
CATO-2328 - fix for space characters being suppressed

### DIFF
--- a/assets/javascripts/modules/details.polyfill.js
+++ b/assets/javascripts/modules/details.polyfill.js
@@ -26,7 +26,7 @@
   function addClickEvent(node, callback) {
     // Prevent space(32) from scrolling the page
     addEvent(node, 'keypress', function(e, target) {
-      if (e.keyCode === 32) {
+      if (e.keyCode === 32 && e.target == document.body) {
         if (e.preventDefault) {
           e.preventDefault();
         } else {


### PR DESCRIPTION
The suppression of keypress events for spaces was preventing the entry of any spaces on any form fields on the screens that use summary/details widgets (in IE, Chrome & Safari).  Allow the event if the target is anything else other than the document body.